### PR TITLE
removed autoplay from video when entering video page

### DIFF
--- a/src/containers/Story/components/StoryVideo.js
+++ b/src/containers/Story/components/StoryVideo.js
@@ -35,7 +35,6 @@ export const StoryVideo = withRoute(props => {
                             publicId={story.id}
                             format="mp4"
                             controls
-                            autoPlay
                         >
                             <Transformation bitRate="250k" />
                         </Video>


### PR DESCRIPTION
Removed the 'autoplay' attribute which will restrict the video to start playing automatically, when entering the video page.